### PR TITLE
Create inclusive_cleaner.sh

### DIFF
--- a/inclusive_cleaner.sh
+++ b/inclusive_cleaner.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+cleaner () {
+    sed --in-place --regexp-extended "s@$1@$2@g" "$3"
+}
+
+files_list=("admin-fr_FR.mo" "admin-fr_FR.po" "admin-network-fr_FR.mo" "admin-network-fr_FR.po" "fr_FR.mo" "fr_FR.po")
+
+for file in "${files_list[@]}"
+do
+echo "> Working on file $file"
+    # auteur/autrice
+    cleaner "/autrices?" "" "$file"
+    # auteurs ou autrices
+    # Auteur ou autrice
+    cleaner " ou autrices?" "" "$file"
+    # de l’auteur ou de l’autrice
+    cleaner " ou de l’autrice" "" "$file"
+    # l’auteur ou l’autrice
+    cleaner " ou l’autrice" "" "$file"
+    # l’auteur ou autrice
+    cleaner " ou autrice" "" "$file"
+    # d’auteur ou d’autrice
+    cleaner " ou d’autrice" "" "$file"
+    # un auteur ou une autrice
+    cleaner " ou une autrice" "" "$file"
+
+    # administrateurs/administratrices
+    # administrateur/administratrice
+    cleaner "/administratrices?" "" "$file"
+    # administrateurs ou administratrices
+    # administrateur ou administratrice
+    cleaner " ou administratrices?" "" "$file"
+    # l’administrateur ou l’administratrice
+    cleaner " ou l’administratrice" "" "$file"
+    # l’administrateur ou de l’administratrice
+    cleaner " ou de l’administratrice" "" "$file"
+    # l’administrateur ou à l’administratrice
+    cleaner " ou à l’administratrice" "" "$file"
+    # les administrateurs et les administratrices
+    cleaner " et les administratrices" "" "$file"
+    # un administrateur ou une administratrice
+    cleaner " ou une administratrice" "" "$file"
+    # administrateur, administratrice
+    cleaner ", administratrice" "" "$file"
+
+    # une développeuse ou un développeur
+    cleaner "une développeuse ou " "" "$file"
+    # les développeurs et les développeuses
+    cleaner " et les développeuses" "" "$file"
+
+    # éditeur/éditrice
+    cleaner "/éditrices?" "" "$file"
+    # éditeurs ou éditrices
+    cleaner " ou éditrices?" "" "$file"
+
+    # contributeur/contributrice
+    cleaner "/contributrices?" "" "$file"
+    # Contributrices & contributeurs
+    cleaner "Contributrices & c" "C" "$file"
+
+    # Traductrices & traducteurs
+    cleaner "Traductrices & t" "T" "$file"
+
+    # utilisateur/utilisatrice
+    cleaner "/utilisatrices?" "" "$file"
+    # utilisateur ou utilisatrice
+    cleaner " ou utilisatrice" "" "$file"
+    # l’utilisateur ou l’utilisatrice
+    cleaner " ou l’utilisatrice" "" "$file"
+    # l’utilisateur ou à l’utilisatrice
+    cleaner " ou à l’utilisatrice" "" "$file"
+    # l’utilisateur ou de l’utilisatrice
+    cleaner " ou de l’utilisatrice" "" "$file"
+    # l’utilisateur et l’utilisatrice
+    cleaner " et l’utilisatrice" "" "$file"
+    # Utilisateurs et utilisatrices
+    cleaner " et utilisatrices" "" "$file"
+
+    # du commentateur ou de la commentatrice
+    cleaner " ou de la commentatrice" "" "$file"
+
+    # abonné/abonnée
+    cleaner "/abonnées?" "" "$file"
+
+    # connecté·e
+    # déconnecté·e
+    # notifié·e
+    # reconnecté·e
+    # invité·e
+    # rencontré·e
+    cleaner "é·e" "é" "$file"
+    # certain·e
+    # prêt·e
+    # petit·e ami·e
+    cleaner "·e" "" "$file"
+done

--- a/inclusive_cleaner.sh
+++ b/inclusive_cleaner.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 cleaner () {
+    # Remplace toutes les occurences dans le fichier cible
     sed --in-place --regexp-extended "s@$1@$2@g" "$3"
 }
 
@@ -9,6 +10,10 @@ files_list=("admin-fr_FR.mo" "admin-fr_FR.po" "admin-network-fr_FR.mo" "admin-ne
 for file in "${files_list[@]}"
 do
 echo "> Working on file $file"
+
+    # Sauvegarde le fichier original, par sécurité et pour le diff
+    cp -a "$file" "$file.backup"
+
     # auteur/autrice
     cleaner "/autrices?" "" "$file"
     # auteurs ou autrices
@@ -94,4 +99,7 @@ echo "> Working on file $file"
     # prêt·e
     # petit·e ami·e
     cleaner "·e" "" "$file"
+
+    # Créer un diff du fichier modifié par rapport à la version originale
+    git --no-pager diff --unified=0 --word-diff=color --no-index "$file.backup" "$file"
 done


### PR DESCRIPTION
En me basant sur le travail qui a déjà été fait, j'ai identifié les différents éléments de langage inclusif à retirer.

Je suis parvenu à ce script simple, c'est une première version faite rapidement.
Il travaille uniquement sur les fichiers de traduction qui ont déjà été corrigés dans ce dépot. Mais il pourrait travailler avec toutes les traductions FR d'un blog.

J'ai gardé une syntaxe claire sans trop de factorisation pour faciliter l'ajout de filtres par la suite.

Ce script va simplement lire chaque fichier de traduction et le débarrasser des éléments de langage inclusif automatiquement.

Je l'ai testé sur une installation à jour de wordpress avec la traduction française. J'obtiens la même correction non inclusive que la version de ce dépot.
Je vérifie les résultats avec `git diff --no-index --unified=0 -- fichier1 fichier2`